### PR TITLE
Detect if we need to reboot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,8 @@
     name: systemd-networkd
     state: restarted
   when: systemd_networkd_apply_config
+
+- name: check reboot
+  set_fact:
+    need_reboot: true
+  when: not systemd_networkd_apply_config

--- a/tasks/profiles.yml
+++ b/tasks/profiles.yml
@@ -8,7 +8,9 @@
     group: systemd-network
     mode: 0640
   loop: "{{ systemd_networkd_link | dict2items }}"
-  notify: restart systemd-networkd
+  notify:
+    - restart systemd-networkd
+    - check reboot
 
 - name: copy .netdev profiles
   template:
@@ -18,7 +20,9 @@
     group: systemd-network
     mode: 0640
   loop: "{{ systemd_networkd_netdev | dict2items }}"
-  notify: restart systemd-networkd
+  notify:
+    - restart systemd-networkd
+    - check reboot
 
 - name: copy .network profiles
   template:
@@ -28,6 +32,8 @@
     group: systemd-network
     mode: 0640
   loop: "{{ systemd_networkd_network | dict2items }}"
-  notify: restart systemd-networkd
+  notify:
+    - restart systemd-networkd
+    - check reboot
 
 # vim: set ts=2 sw=2:


### PR DESCRIPTION
When restarted systemd-networkd is disabled, detect if we need to reboot to apply the new network configuration and set the Ansible fact variable need_reboot to true if it is the case.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>