### PR TITLE
handlers: use udevadm trigger instead of restarting udev

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,5 +6,3 @@ systemd_networkd_network: {}
 
 systemd_networkd_apply_config: false
 systemd_networkd_enable_resolved: true
-
-service_name_udev: "systemd-udev-trigger"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,7 @@
 # handlers for ansible-role-systemd-networkd
 
 - name: restart udev
-  service:
-    name: "{{ service_name_udev }}"
-    state: restarted
+  command: udevadm trigger
 
 - name: reload systemd-networkd
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,5 @@
 ---
 
-- include_vars: "{{ ansible_distribution | replace(' ', '_') }}.yml"
-  ignore_errors: yes
-
 - import_tasks: profiles.yml
 
 - name: enable systemd-networkd

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,5 +1,0 @@
-# Copyright (C) 2024 RTE
-# SPDX-License-Identifier: Apache-2.0
-
----
-service_name_udev: "systemd-udevd"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,0 @@
-# Copyright (C) 2024 RTE
-# SPDX-License-Identifier: Apache-2.0
-
----
-service_name_udev: "systemd-udev-trigger"

--- a/vars/Seapath_host_Yocto_distribution.yml
+++ b/vars/Seapath_host_Yocto_distribution.yml
@@ -1,5 +1,0 @@
-# Copyright (C) 2024 RTE
-# SPDX-License-Identifier: Apache-2.0
-
----
-service_name_udev: "systemd-udevd"


### PR DESCRIPTION
udevadm trigger is the recommended way to reload udev rules and devices.

This also avoid checking the service name for each distribution.